### PR TITLE
Mesh4 insert point

### DIFF
--- a/board.txt
+++ b/board.txt
@@ -16,9 +16,9 @@ mesh 3 - write add_point and find point methods     x
     (2) write unit tests                            x
     (3) update docs                                 x
 
-mesh 4 - write insert_point method
-    (1) decide how insert_point should be called
+mesh 4 - write insert_point method                  x
+    (1) decide how insert_point should be called    x
         - can I call after being closed?
-    (2) implement insert_point based on this
-    (3) write unit tests
-    (4) update docs
+    (2) implement insert_point based on this        x
+    (3) write unit tests                            x
+    (4) update docs                                 x

--- a/src/mesher/geometry/abc.py
+++ b/src/mesher/geometry/abc.py
@@ -161,7 +161,7 @@ class IRing(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def insert_point(self, point: IPoint, location: int) -> None:
-        """This inserts a point into the ring if the ring is not closed."""
+        """This inserts a point into the ring."""
 
         ...
 

--- a/src/mesher/geometry/ring.py
+++ b/src/mesher/geometry/ring.py
@@ -567,7 +567,32 @@ class Ring(IRing):
         ...
 
     def insert_point(self, point: IPoint, location: int) -> None:
-        ...
+        """
+        This inserts a point into the ring. This will insert the point at the given
+        index. If the ring is already closed, then it will delete the connections of
+        the nodes before and after this new point and connect themselves to the node.
+
+        Args:
+            point:
+                ...
+            location:
+                ...
+
+        Example:
+            TODO: fill in this example
+        """
+
+        closed: bool = self.closed
+        self._nodes.insert(location, Node(point))
+        if closed:
+            self._nodes[location - 1].del_connection(NeighborOption.RIGHT)
+            self._nodes[location - 1].right = self._nodes[location]
+
+            self._nodes[location].left = self._nodes[location - 1]
+            self._nodes[location].right = self._nodes[(location + 1) % len(self)]
+
+            self._nodes[(location + 1) % len(self)].del_connection(NeighborOption.LEFT)
+            self._nodes[(location + 1) % len(self)].left = self._nodes[location]
 
     def remove_collinear(self) -> None:
         ...

--- a/test/geometry/test_ring.py
+++ b/test/geometry/test_ring.py
@@ -245,3 +245,29 @@ def test_ring_find_point(sample_rings, scenario, point, loc):
         assert sample_rings[scenario].find_point(point) == loc
     else:
         assert sample_rings[scenario].find_point(point) is None
+
+
+def test_ring_insert_point_open(sample_rings, sample_points):
+    """This tests inserting a new point in an open ring."""
+
+    for scenario, ring in sample_rings.items():
+        if "open" in scenario:
+            ring.insert_point(Point(x=-1, y=-1, ID=10), 1)
+
+            assert len(ring._nodes) == len(sample_points[scenario]) + 1
+            assert ring._nodes[1].value == Point(x=-1, y=-1, ID=10)
+
+
+def test_ring_insert_point_closed(sample_rings, sample_points):
+    """This tests inserting a new point in an closed ring."""
+
+    for scenario, ring in sample_rings.items():
+        if "closed" in scenario:
+            ring.insert_point(Point(x=-1, y=-1, ID=10), 1)
+
+            assert len(ring._nodes) == len(sample_points[scenario]) + 1
+            assert ring._nodes[1].value == Point(x=-1, y=-1, ID=10)
+            assert ring._nodes[0].right.value.ID == 10
+            assert ring._nodes[1].left.value.ID == sample_points[scenario][0].ID
+            assert ring._nodes[1].right.value.ID == sample_points[scenario][1].ID
+            assert ring._nodes[2].left.value.ID == 10


### PR DESCRIPTION
* Decided that [`insert_point()`][mesher.geometry.ring.Ring] should allow points to be inserted after the `Ring` has been closed.
    - In order to allow for this, the `Ring` will delete previous connections and add the new ones.
    - Only works for closed rings. Open rings will just insert the point.
* Wrote unit tests
* Updated docs...