### PR TITLE
Mesh6 reverse ring

### DIFF
--- a/board.txt
+++ b/board.txt
@@ -29,8 +29,8 @@ mesh 5 - write close method                         x
     (2) write unit tests                            x
     (3) update/add docs...                          x
 
-mesh 6 - reverse ring
-    (1) decide when reverse should be called
-    (2) write implementation
-    (3) write unit tests
-    (4) docs...
+mesh 6 - reverse ring                               x
+    (1) decide when reverse should be called        x
+    (2) write implementation                        x
+    (3) write unit tests                            x
+    (4) docs...                                     x

--- a/board.txt
+++ b/board.txt
@@ -28,3 +28,9 @@ mesh 5 - write close method                         x
     (2) allow users to print nodes to screen        x
     (2) write unit tests                            x
     (3) update/add docs...                          x
+
+mesh 6 - reverse ring
+    (1) decide when reverse should be called
+    (2) write implementation
+    (3) write unit tests
+    (4) docs...

--- a/src/mesher/geometry/abc.py
+++ b/src/mesher/geometry/abc.py
@@ -172,6 +172,12 @@ class IRing(metaclass=abc.ABCMeta):
         ...
 
     @abc.abstractmethod
+    def reverse_orientation(self) -> None:
+        """This reversed the orientation of a closed ring."""
+
+        ...
+
+    @abc.abstractmethod
     def split_ring(self) -> list[IRing]:
         """This splits a ring that has self-intersections into multiple,
         non-self-intersecting rings."""

--- a/src/mesher/geometry/ring.py
+++ b/src/mesher/geometry/ring.py
@@ -763,5 +763,69 @@ class Ring(IRing):
     def remove_collinear(self) -> None:
         ...
 
+    def reverse_orientation(self) -> None:
+        """
+        This reversed the orientation of a closed ring. This will also swap the left
+        and right connections of each node.
+
+        Example:
+            ```py
+            >>> ring = Ring()
+            >>> ring.add_point(Point(x=0, y=0, ID=0))
+            >>> ring.add_point(Point(x=1, y=0, ID=1))
+            >>> ring.add_point(Point(x=1, y=1, ID=2))
+            >>> ring.close()
+            >>> print(ring)
+            Ring(
+                nodes=[
+                    Node(
+                value=Point(x=0, y=0, ID=0),
+                left.ID=2,
+                right.ID=1,
+                    ),
+                    Node(
+                value=Point(x=1, y=0, ID=1),
+                left.ID=0,
+                right.ID=2,
+                    ),
+                    Node(
+                value=Point(x=1, y=1, ID=2),
+                left.ID=1,
+                right.ID=0,
+                    ),
+                ]
+            )
+            >>> ring.reverse_orientation()
+            >>> print(ring)
+            Ring(
+                nodes=[
+                    Node(
+                value=Point(x=1, y=1, ID=2),
+                left.ID=0,
+                right.ID=1,
+                    ),
+                    Node(
+                value=Point(x=1, y=0, ID=1),
+                left.ID=2,
+                right.ID=0,
+                    ),
+                    Node(
+                value=Point(x=0, y=0, ID=0),
+                left.ID=1,
+                right.ID=2,
+                    ),
+                ]
+            )
+            ```
+        """
+
+        if self.closed:
+            self._nodes.reverse()
+            for node in self._nodes:
+                left, right = node.left, node.right
+                node.del_connection(NeighborOption.LEFT)
+                node.del_connection(NeighborOption.RIGHT)
+                node.left, node.right = right, left
+
     def split_ring(self) -> list[IRing]:
         ...

--- a/test/geometry/test_ring.py
+++ b/test/geometry/test_ring.py
@@ -297,3 +297,37 @@ def test_ring_insert_point_closed(sample_rings, sample_points):
             assert ring._nodes[1].left.value.ID == sample_points[scenario][0].ID
             assert ring._nodes[1].right.value.ID == sample_points[scenario][1].ID
             assert ring._nodes[2].left.value.ID == 10
+
+
+@pytest.mark.parametrize(
+    "scenario,orient1,orient2",
+    [
+        ("closed,CCW,convex", Orientation.CCW, Orientation.CW),
+        ("closed,CW,convex", Orientation.CW, Orientation.CCW),
+        ("closed,CCW,concave", Orientation.CCW, Orientation.CW),
+        ("closed,CW,concave", Orientation.CW, Orientation.CCW),
+    ]
+)
+def test_ring_reverse_orientation(
+    sample_rings, sample_points, scenario, orient1, orient2
+):
+    """This tests the ability to reverse a ring's orientation."""
+
+    ring: Ring = sample_rings[scenario]
+    assert ring.orientation == orient1
+    for n, node in enumerate(ring._nodes):
+        n_before: int = n - 1
+        n_after: int = (n + 1) % len(ring._nodes)
+
+        assert node.left.value.ID == sample_points[scenario][n_before].ID
+        assert node.right.value.ID == sample_points[scenario][n_after].ID
+
+    ring.reverse_orientation()
+    sample_points[scenario].reverse()
+    assert ring.orientation == orient2
+    for n, node in enumerate(ring._nodes):
+        n_before: int = n - 1
+        n_after: int = (n + 1) % len(ring._nodes)
+
+        assert node.left.value.ID == sample_points[scenario][n_before].ID
+        assert node.right.value.ID == sample_points[scenario][n_after].ID

--- a/test/geometry/test_ring.py
+++ b/test/geometry/test_ring.py
@@ -306,7 +306,7 @@ def test_ring_insert_point_closed(sample_rings, sample_points):
         ("closed,CW,convex", Orientation.CW, Orientation.CCW),
         ("closed,CCW,concave", Orientation.CCW, Orientation.CW),
         ("closed,CW,concave", Orientation.CW, Orientation.CCW),
-    ]
+    ],
 )
 def test_ring_reverse_orientation(
     sample_rings, sample_points, scenario, orient1, orient2


### PR DESCRIPTION
* Decided that we need to be able to reverse the orientation of rings - figures' outer points should be CCW and any inner points should be CW.
* Wrote [`reverse_orientation()`][mesher.geometry.ring.Ring] method to do this, also updates connections by flipping them
* Wrote unit test
* Wrote more docs