### PR TITLE
Mesh8 ring equality

### DIFF
--- a/board.txt
+++ b/board.txt
@@ -41,3 +41,8 @@ mesh 7 - remove collinear points                    x
     (3) write implementation to delete collinears   x
     (4) write unit tests                            x
     (5) docs...                                     x
+
+mesh 8 - ring equality                              x
+    (1) write == overload for rings                 x
+    (2) update/write unit tests                     x
+    (3) docs...                                     x

--- a/src/mesher/geometry/ring.py
+++ b/src/mesher/geometry/ring.py
@@ -374,22 +374,24 @@ class Ring(IRing):
 
         if len(self) != len(other):
             return False
-        
+
         if self[0] not in other:
             return False
-        
+
         ptr0: int = other.find_point(self[0]) + 1
         ptr1: int = 1
         while True:
-            if self[ptr0] != other[ptr1]:
+            node1: Node = self._nodes[ptr0]
+            node2: Node = other._nodes[ptr1]
+            if node1.value != node2.value:
                 return False
-            
+
             if (
-                self._nodes[ptr0].left.value != other._nodes[ptr1].left.value or
-                self._nodes[ptr0].right.value != other._nodes[ptr1].right.value
+                node1.left.value != node2.left.value
+                or node1.right.value != node2.right.value  # noqa: W503
             ):
                 return False
-            
+
             ptr0: int = (ptr0 + 1) % len(self)
             ptr1: int = (ptr1 + 1) % len(other)
             if ptr1 == 0:

--- a/src/mesher/geometry/ring.py
+++ b/src/mesher/geometry/ring.py
@@ -342,7 +342,60 @@ class Ring(IRing):
         return False
 
     def __eq__(self, other: IRing) -> bool:
-        ...
+        """
+        This checks if two rings are equal within tolerance. This will first check that
+        the number of points are equal, and that all the points line up by checking
+        that (a) the points are equal, and (b) the ordering of the points is equal.
+
+        Args:
+            other:
+                ...
+
+        Returns:
+            flag:
+                ...
+
+        Example:
+            ```py
+            >>> ring1 = Ring()
+            >>> ring1.add_point(Point(x=0, y=0, ID=0))
+            >>> ring1.add_point(Point(x=1, y=1, ID=1))
+            >>> ring1.add_point(Point(x=0, y=2, ID=2))
+            >>> ring1.close()
+            >>> ring2 = Ring()
+            >>> ring2.add_point(Point(x=0, y=0, ID=3))
+            >>> ring2.add_point(Point(x=1, y=1, ID=4))
+            >>> ring2.add_point(Point(x=0, y=2, ID=5))
+            >>> ring2.close()
+            >>> ring1 == ring2
+            True
+            ```
+        """
+
+        if len(self) != len(other):
+            return False
+        
+        if self[0] not in other:
+            return False
+        
+        ptr0: int = other.find_point(self[0]) + 1
+        ptr1: int = 1
+        while True:
+            if self[ptr0] != other[ptr1]:
+                return False
+            
+            if (
+                self._nodes[ptr0].left.value != other._nodes[ptr1].left.value or
+                self._nodes[ptr0].right.value != other._nodes[ptr1].right.value
+            ):
+                return False
+            
+            ptr0: int = (ptr0 + 1) % len(self)
+            ptr1: int = (ptr1 + 1) % len(other)
+            if ptr1 == 0:
+                break
+
+        return True
 
     def __getitem__(self, index: int) -> IPoint:
         """

--- a/test/geometry/test_ring.py
+++ b/test/geometry/test_ring.py
@@ -86,6 +86,112 @@ def test_ring_contains(sample_rings):
     assert point2 not in sample_rings["closed,CCW,convex"]
 
 
+def test_ring_equality_not_equal_length():
+    """This tests ring equal when they do not have equal length."""
+
+    ring1: Ring = Ring()
+    ring2: Ring = Ring()
+
+    ring1.add_point(Point(x=0, y=0, ID=0))
+    ring1.add_point(Point(x=1, y=0, ID=1))
+    ring1.add_point(Point(x=1, y=1, ID=2))
+
+    ring2.add_point(Point(x=0, y=0, ID=0))
+    ring2.add_point(Point(x=1, y=0, ID=1))
+    ring2.add_point(Point(x=1, y=1, ID=2))
+    ring2.add_point(Point(x=0, y=1, ID=3))
+
+    assert ring1 != ring2
+
+
+def test_ring_equality_missing_first_point():
+    """This tests ring equal when the first point cannot be found."""
+
+    ring1: Ring = Ring()
+    ring2: Ring = Ring()
+
+    ring1.add_point(Point(x=1, y=-1, ID=0))
+    ring1.add_point(Point(x=2, y=-1, ID=1))
+    ring1.add_point(Point(x=2, y=0, ID=2))
+    ring1.add_point(Point(x=1, y=0, ID=3))
+
+    ring2.add_point(Point(x=0, y=0, ID=0))
+    ring2.add_point(Point(x=1, y=0, ID=1))
+    ring2.add_point(Point(x=1, y=1, ID=2))
+    ring2.add_point(Point(x=0, y=1, ID=3))
+
+    assert ring1 != ring2
+
+
+def test_ring_equality_points_not_equal():
+    """This tests ring equal when the remainder of the points are not equal."""
+
+    ring1: Ring = Ring()
+    ring2: Ring = Ring()
+
+    ring1.add_point(Point(x=0, y=0, ID=0))
+    ring1.add_point(Point(x=2, y=0, ID=1))
+    ring1.add_point(Point(x=2, y=1, ID=2))
+    ring1.add_point(Point(x=0, y=1, ID=3))
+
+    ring2.add_point(Point(x=0, y=0, ID=0))
+    ring2.add_point(Point(x=1, y=0, ID=1))
+    ring2.add_point(Point(x=1, y=1, ID=2))
+    ring2.add_point(Point(x=0, y=1, ID=3))
+
+    ring1 != ring2
+
+
+def test_ring_equality_edges_not_equal():
+    """This tests ring equal when the edges don't line up."""
+
+    ring1: Ring = Ring()
+    ring2: Ring = Ring()
+
+    ring1.add_point(Point(x=0, y=0, ID=0))
+    ring1.add_point(Point(x=1, y=0, ID=1))
+    ring1.add_point(Point(x=1, y=1, ID=2))
+    ring1.add_point(Point(x=0, y=1, ID=3))
+
+    ring1._nodes[0].left = ring1._nodes[2]
+    ring1._nodes[0].right = ring1._nodes[1]
+    ring1._nodes[1].left = ring1._nodes[0]
+    ring1._nodes[1].right = ring1._nodes[3]
+    ring1._nodes[2].left = ring1._nodes[3]
+    ring1._nodes[2].right = ring1._nodes[0]
+    ring1._nodes[3].left = ring1._nodes[1]
+    ring1._nodes[3].right = ring1._nodes[2]
+
+    ring2.add_point(Point(x=0, y=0, ID=0))
+    ring2.add_point(Point(x=1, y=0, ID=1))
+    ring2.add_point(Point(x=1, y=1, ID=2))
+    ring2.add_point(Point(x=0, y=1, ID=3))
+    ring2.close()
+
+    assert ring1 != ring2
+
+
+def test_ring_equality():
+    """This tests ring equal"""
+
+    ring1: Ring = Ring()
+    ring2: Ring = Ring()
+
+    ring1.add_point(Point(x=0, y=0, ID=0))
+    ring1.add_point(Point(x=1, y=0, ID=1))
+    ring1.add_point(Point(x=1, y=1, ID=2))
+    ring1.add_point(Point(x=0, y=1, ID=3))
+    ring1.close()
+
+    ring2.add_point(Point(x=0, y=0, ID=0))
+    ring2.add_point(Point(x=1, y=0, ID=1))
+    ring2.add_point(Point(x=1, y=1, ID=2))
+    ring2.add_point(Point(x=0, y=1, ID=3))
+    ring2.close()
+
+    assert ring1 == ring2
+
+
 def test_ring_getitem(sample_rings, sample_points):
     """This tests ring getitem operator."""
 


### PR DESCRIPTION
* _Finally_ wrote ring equality which is needed for the first part of meshing.
    - Checks ring lengths are equal
    - Checks if the first point is in the other ring
    - Creates two pointers: one pointing to the first point of current ring, the other to where first point is in other ring.
    - Checks all points are equal and all edges are equal
        o Checks left connection and right connection are equal
* Wrote unit tests
* Updated docs